### PR TITLE
Feat/add_socre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .claude
+
+.mcp.json

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,8 @@ model matches {
   section                           Int
   category                          String    @db.VarChar(50)
   created_at                        DateTime? @default(now()) @db.Timestamp(6)
+  score                             String?   @db.VarChar(20)
+  attendance                        Int?
   teams_matches_away_team_idToteams teams?    @relation("matches_away_team_idToteams", fields: [away_team_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_away_team")
   teams_matches_home_team_idToteams teams?    @relation("matches_home_team_idToteams", fields: [home_team_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_home_team")
   stadiums                          stadiums? @relation(fields: [stadium_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_stadium")

--- a/src/app/api/scraping/match/route.ts
+++ b/src/app/api/scraping/match/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from "next/server";
-import * as cheerio from "cheerio";
+import type { ApiResponse, MatchScrapingData } from "@/types";
 import { createClient } from "@/utils/supabase/auth/server";
-import type { MatchScrapingData, ApiResponse } from "@/types";
+import * as cheerio from "cheerio";
+import { NextResponse } from "next/server";
 
 // 定数定義
-const SCRAPING_URL = "https://data.j-league.or.jp/SFMS01/search?competition_years=2025&competition_frame_ids=1&competition_frame_ids=2&competition_frame_ids=3&tv_relay_station_name=";
-
+const SCRAPING_URL =
+  "https://data.j-league.or.jp/SFMS01/search?competition_years=2025&competition_frame_ids=1&competition_frame_ids=2&competition_frame_ids=3&tv_relay_station_name=";
 
 interface RawMatchData {
   year?: string;
@@ -16,6 +16,8 @@ interface RawMatchData {
   home?: string;
   away?: string;
   stadium?: string;
+  score?: string;
+  attendance?: string;
 }
 
 // 日付の最適化関数
@@ -24,9 +26,10 @@ function optimizeDate(item: RawMatchData): string | null {
     return null;
   }
 
-  const kickoffTime = item.kickoffTime && !item.kickoffTime.includes("未定") 
-    ? item.kickoffTime 
-    : "00:00";
+  const kickoffTime =
+    item.kickoffTime && !item.kickoffTime.includes("未定")
+      ? item.kickoffTime
+      : "00:00";
 
   // 日本語の曜日や記号を削除し、スラッシュをハイフンに変換
   const cleanedDate = item.date
@@ -39,8 +42,10 @@ function optimizeDate(item: RawMatchData): string | null {
   }
 
   const dateString = `${item.year.padStart(4, "0")}-${cleanedDate.padStart(5, "0")}`;
-  const timeString = kickoffTime.includes(":") ? `${kickoffTime}:00` : "00:00:00";
-  
+  const timeString = kickoffTime.includes(":")
+    ? `${kickoffTime}:00`
+    : "00:00:00";
+
   try {
     const date = new Date(`${dateString}T${timeString}+09:00`);
     return isNaN(date.getTime()) ? null : date.toISOString();
@@ -51,19 +56,29 @@ function optimizeDate(item: RawMatchData): string | null {
 
 // セクション番号の正規化
 function normalizeSection(sectionText: string): number | null {
-  const normalizedText = sectionText.replace(/[０-９]/g, (s) =>
-    String.fromCharCode(s.charCodeAt(0) - 0xfee0)
+  const normalizedText = sectionText.replace(/[０-９]/g, s =>
+    String.fromCharCode(s.charCodeAt(0) - 0xfee0),
   );
   const match = normalizedText.match(/\d+/);
   return match ? Number(match[0]) : null;
 }
 
+// チーム名の正規化（半角→全角変換）
+function normalizeTeamName(teamName: string): string {
+  return teamName.replace(/[A-Za-z]/g, s => {
+    return String.fromCharCode(s.charCodeAt(0) + 0xfee0);
+  });
+}
+
 // スクレイピングデータの変換
-function transformScrapingData(headers: string[], rowData: Record<string, string>): MatchScrapingData | null {
+function transformScrapingData(
+  headers: string[],
+  rowData: Record<string, string>,
+): MatchScrapingData | null {
   const rawData: RawMatchData = {};
-  
+
   // ヘッダーに基づいてデータをマッピング
-  headers.forEach((header) => {
+  headers.forEach(header => {
     if (header === "年度") rawData.year = rowData[header];
     else if (header === "試合日") rawData.date = rowData[header];
     else if (header === "K/O時刻") rawData.kickoffTime = rowData[header];
@@ -72,10 +87,20 @@ function transformScrapingData(headers: string[], rowData: Record<string, string
     else if (header === "ホーム") rawData.home = rowData[header];
     else if (header === "アウェイ") rawData.away = rowData[header];
     else if (header === "スタジアム") rawData.stadium = rowData[header];
+    else if (header === "スコア") rawData.score = rowData[header];
+    else if (header === "入場者数") rawData.attendance = rowData[header];
   });
 
   const date = optimizeDate(rawData);
   const section = rawData.section ? normalizeSection(rawData.section) : null;
+
+  // 入場者数の処理（カンマを除去して数値に変換）
+  const attendance =
+    rawData.attendance &&
+    rawData.attendance !== "-" &&
+    rawData.attendance.trim() !== ""
+      ? Number(rawData.attendance.replace(/,/g, "")) || null
+      : null;
 
   if (!rawData.category || !rawData.home || !rawData.away || !rawData.stadium) {
     return null;
@@ -85,17 +110,26 @@ function transformScrapingData(headers: string[], rowData: Record<string, string
     date,
     category: rawData.category,
     section,
-    home: rawData.home,
-    away: rawData.away,
+    home: normalizeTeamName(rawData.home),
+    away: normalizeTeamName(rawData.away),
     stadium: rawData.stadium,
+    score:
+      rawData.score &&
+      rawData.score !== "-" &&
+      rawData.score.trim() !== "" &&
+      rawData.score !== "vs"
+        ? rawData.score
+        : null,
+    attendance,
   };
 }
 
-export async function GET(): Promise<NextResponse<ApiResponse<{ count: number }>>> {
+export async function GET(): Promise<
+  NextResponse<ApiResponse<{ count: number }>>
+> {
   try {
     const supabase = await createClient();
 
-    // 1. データのスクレイピング
     const response = await fetch(SCRAPING_URL);
     if (!response.ok) {
       throw new Error(`Failed to fetch data: ${response.statusText}`);
@@ -103,19 +137,20 @@ export async function GET(): Promise<NextResponse<ApiResponse<{ count: number }>
 
     const body = await response.text();
     const $ = cheerio.load(body);
-    
+
     const headers = $("thead tr th")
       .map((_, th) => $(th).text().trim())
       .get();
 
     const matches: MatchScrapingData[] = [];
-    
     $("tbody tr").each((_, tr) => {
       const rowData: Record<string, string> = {};
-      $(tr).find("td").each((index, td) => {
-        rowData[headers[index]] = $(td).text().trim();
-      });
-      
+      $(tr)
+        .find("td")
+        .each((index, td) => {
+          rowData[headers[index]] = $(td).text().trim();
+        });
+
       const matchData = transformScrapingData(headers, rowData);
       if (matchData) {
         matches.push(matchData);
@@ -126,7 +161,7 @@ export async function GET(): Promise<NextResponse<ApiResponse<{ count: number }>
     const { data: teams } = await supabase
       .from("teams")
       .select("id, short_name");
-    
+
     const { data: stadiums } = await supabase
       .from("stadiums")
       .select("id, shortName");
@@ -136,7 +171,9 @@ export async function GET(): Promise<NextResponse<ApiResponse<{ count: number }>
     }
 
     const teamMap = new Map(teams.map(team => [team.short_name, team.id]));
-    const stadiumMap = new Map(stadiums.map(stadium => [stadium.shortName, stadium.id]));
+    const stadiumMap = new Map(
+      stadiums.map(stadium => [stadium.shortName, stadium.id]),
+    );
 
     // 3. IDをマッピング
     const matchesWithIds = matches.map(match => ({
@@ -156,7 +193,12 @@ export async function GET(): Promise<NextResponse<ApiResponse<{ count: number }>
         stadium_id: match.stadium_id,
         section: match.section,
         category: match.category,
+        score: match.score,
+        attendance: match.attendance,
       }));
+
+    // 重複データの事前削除
+    await supabase.rpc("delete_duplicate_matches");
 
     // バッチ処理で挿入
     const batchSize = 100;
@@ -164,36 +206,35 @@ export async function GET(): Promise<NextResponse<ApiResponse<{ count: number }>
 
     for (let i = 0; i < insertData.length; i += batchSize) {
       const batch = insertData.slice(i, i + batchSize);
-      const { data, error } = await supabase
-        .from("matches")
-        .upsert(batch, {
-          onConflict: "date,home_team_id,away_team_id",
-          ignoreDuplicates: false,
-        })
-        .select();
+      // PostgreSQL関数を使用して日付ベースupsert
+      const { error } = await supabase.rpc("upsert_matches_by_date", {
+        matches_data: batch,
+      });
 
       if (error) {
-        // eslint-disable-next-line no-console
-        console.error(`Batch ${i / batchSize + 1} failed:`, error);
-      } else if (data) {
-        totalInserted += data.length;
+        throw new Error(
+          `Database insertion failed: ${error.message || "Unknown error"}`,
+        );
+      } else {
+        totalInserted += batch.length;
       }
     }
+
+    // 最終的な重複チェック
+    await supabase.rpc("delete_duplicate_matches");
 
     return NextResponse.json({
       data: { count: totalInserted },
       message: `Successfully imported ${totalInserted} matches`,
     });
-
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error("Match scraping error:", error);
     return NextResponse.json(
       {
-        error: error instanceof Error ? error.message : "Unknown error occurred",
+        error:
+          error instanceof Error ? error.message : "Unknown error occurred",
         message: "Failed to scrape and import matches",
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/components/organisms/Matches/MatchCard/index.tsx
+++ b/src/components/organisms/Matches/MatchCard/index.tsx
@@ -28,7 +28,7 @@ export const MatchCard: FC<Props> = ({ match }) => {
         <Flex px="lg" py="sm" justify="space-between">
           <Text flex={1}>{match.homeTeam}</Text>
           <Text ta="center" flex={1}>
-            未定
+            {match.score || "未定"}
           </Text>
           <Text ta="right" flex={1}>
             {match.awayTeam}
@@ -58,7 +58,7 @@ export const MatchCard: FC<Props> = ({ match }) => {
       <Flex px="lg" py="sm" justify="space-between">
         <Text flex={1}>{match.homeTeam}</Text>
         <Text ta="center" flex={1}>
-          {hour}時{minute}分
+          {match.score || `${hour}時${minute}分`}
         </Text>
         <Text ta="right" flex={1}>
           {match.awayTeam}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -13,6 +13,8 @@ export interface MatchScrapingData {
   home: string;
   away: string;
   stadium: string;
+  score: string | null;
+  attendance: number | null;
   home_team_id?: number;
   away_team_id?: number;
   stadium_id?: number;

--- a/src/utils/supabase/db/actions.ts
+++ b/src/utils/supabase/db/actions.ts
@@ -42,6 +42,7 @@ export interface MatchListItem {
   stadium: string | null | undefined;
   date: Date | null;
   stadiumId: number | null;
+  score: string | null;
 }
 
 export interface TagItem {
@@ -227,6 +228,9 @@ export const getMatchesByTeam = async (teamId: number, gte: string): Promise<Mat
         teams_matches_away_team_idToteams: true,
         stadiums: true,
       },
+      orderBy: {
+        date: "asc",
+      },
     });
     return matches.map((match) => {
       return {
@@ -237,6 +241,7 @@ export const getMatchesByTeam = async (teamId: number, gte: string): Promise<Mat
         stadium: match.stadiums?.shortName,
         date: match.date,
         stadiumId: match.stadium_id,
+        score: match.score,
       };
     });
   } catch {


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

試合データの表示機能を拡張し、スコアと観客数の追跡・表示機能を追加するPRです。データベーススキーマの更新とUIの改善が含まれています。

- `prisma/schema.prisma`にスコア（VARCHAR(20)）と観客数（Int）のNullableフィールドを追加
- `src/components/organisms/Matches/MatchCard/index.tsx`で試合時刻表示部分にスコア表示機能を実装
- `src/app/api/scraping/match/route.ts`でスクレイピング機能を拡張し、チーム名の正規化とバッチ処理を最適化
- `src/utils/supabase/db/actions.ts`で試合データの取得時に日付順での並び替えを実装
- 新しい型定義（`MatchScrapingData`）にスコアと観客数のフィールドを追加



<!-- /greptile_comment -->