### PR TITLE
Phase 2: モバイル対応詳細ページ最適化

### DIFF
--- a/src/components/organisms/Matches/Footer/index.tsx
+++ b/src/components/organisms/Matches/Footer/index.tsx
@@ -16,7 +16,7 @@ export const Footer: FC<Props> = ({ teamId, match_ym }) => {
   const monthAsNumber = parseInt(month ?? "", 10);
 
   return (
-    <Flex justify="space-between">
+    <Flex justify="space-between" p={{ base: "xs", md: "sm" }}>
       <Box>
         {monthAsNumber > 1 && (
           <NavLink
@@ -25,6 +25,9 @@ export const Footer: FC<Props> = ({ teamId, match_ym }) => {
             }`}
             component={Link}
             leftSection={<IconWithText text="前へ" icon="chevronLeft" />}
+            p={{ base: "xs", md: "sm" }}
+            fz={{ base: "xs", md: "sm" }}
+            style={{ minHeight: "44px" }}
           />
         )}
       </Box>
@@ -39,6 +42,9 @@ export const Footer: FC<Props> = ({ teamId, match_ym }) => {
             leftSection={
               <IconWithText text="次へ" icon="chevronRight" rightIcon />
             }
+            p={{ base: "xs", md: "sm" }}
+            fz={{ base: "xs", md: "sm" }}
+            style={{ minHeight: "44px" }}
           />
         )}
       </Box>

--- a/src/components/organisms/Matches/MatchCard/index.tsx
+++ b/src/components/organisms/Matches/MatchCard/index.tsx
@@ -11,9 +11,9 @@ type Props = {
 export const MatchCard: FC<Props> = ({ match }) => {
   if (!match.date) {
     return (
-      <Paper mb="sm" withBorder key={match.id}>
-        <Flex justify="space-between" align="center" px="sm">
-          <Text>
+      <Paper mb={{ base: "xs", md: "sm" }} withBorder key={match.id} p={{ base: "xs", md: "sm" }}>
+        <Flex justify="space-between" align="center" px={{ base: "xs", md: "sm" }}>
+          <Text fz={{ base: "xs", md: "sm" }}>
             {`第${match.section}節`} 日程未定
           </Text>
           <Box>
@@ -21,16 +21,17 @@ export const MatchCard: FC<Props> = ({ match }) => {
               component={Link}
               label={match.stadium}
               href={`/stadiums/${match.stadiumId}`}
+              fz={{ base: "xs", md: "sm" }}
             />
           </Box>
         </Flex>
         <Divider />
-        <Flex px="lg" py="sm" justify="space-between">
-          <Text flex={1}>{match.homeTeam}</Text>
-          <Text ta="center" flex={1}>
+        <Flex px={{ base: "sm", md: "lg" }} py={{ base: "xs", md: "sm" }} justify="space-between">
+          <Text flex={1} fz={{ base: "xs", md: "sm" }}>{match.homeTeam}</Text>
+          <Text ta="center" flex={1} fz={{ base: "xs", md: "sm" }}>
             {match.score || "未定"}
           </Text>
-          <Text ta="right" flex={1}>
+          <Text ta="right" flex={1} fz={{ base: "xs", md: "sm" }}>
             {match.awayTeam}
           </Text>
         </Flex>
@@ -41,9 +42,9 @@ export const MatchCard: FC<Props> = ({ match }) => {
   const { month, day, hour, minute } = formatJstTime(match.date);
 
   return (
-    <Paper mb="sm" withBorder key={match.id}>
-      <Flex justify="space-between" align="center" px="sm">
-        <Text>
+    <Paper mb={{ base: "xs", md: "sm" }} withBorder key={match.id} p={{ base: "xs", md: "sm" }}>
+      <Flex justify="space-between" align="center" px={{ base: "xs", md: "sm" }}>
+        <Text fz={{ base: "xs", md: "sm" }}>
           {`第${match.section}節`} {month}月{day}日
         </Text>
         <Box>
@@ -51,16 +52,17 @@ export const MatchCard: FC<Props> = ({ match }) => {
             component={Link}
             label={match.stadium}
             href={`/stadiums/${match.stadiumId}`}
+            fz={{ base: "xs", md: "sm" }}
           />
         </Box>
       </Flex>
       <Divider />
-      <Flex px="lg" py="sm" justify="space-between">
-        <Text flex={1}>{match.homeTeam}</Text>
-        <Text ta="center" flex={1}>
+      <Flex px={{ base: "sm", md: "lg" }} py={{ base: "xs", md: "sm" }} justify="space-between">
+        <Text flex={1} fz={{ base: "xs", md: "sm" }}>{match.homeTeam}</Text>
+        <Text ta="center" flex={1} fz={{ base: "xs", md: "sm" }}>
           {match.score || `${hour}時${minute}分`}
         </Text>
-        <Text ta="right" flex={1}>
+        <Text ta="right" flex={1} fz={{ base: "xs", md: "sm" }}>
           {match.awayTeam}
         </Text>
       </Flex>

--- a/src/components/organisms/StadiumDetail/index.tsx
+++ b/src/components/organisms/StadiumDetail/index.tsx
@@ -31,16 +31,21 @@ export const StadiumDetail: FC<Props> = async ({ id }) => {
 
   return (
     <Box>
-      <Flex direction="column" gap="sm">
-        <Paper withBorder p="sm" mb="md">
-          <Title fz="lg" order={2}>
+      <Flex direction="column" gap={{ base: "xs", md: "sm" }}>
+        <Paper withBorder p={{ base: "sm", md: "md" }} mb={{ base: "sm", md: "md" }}>
+          <Title fz={{ base: "md", md: "lg" }} order={2}>
             {name}
           </Title>
         </Paper>
         <Box>
-          <Image src={imageUrl ?? ""} radius="none" alt={name || "スタジアム画像"} />
+          <Image 
+            src={imageUrl ?? ""} 
+            radius="none" 
+            alt={name || "スタジアム画像"} 
+            height={{ base: "160px", sm: "200px", md: "240px" }}
+          />
         </Box>
-        <Box mb="sm">
+        <Box mb={{ base: "sm", md: "md" }} px={{ base: "xs", md: "0" }}>
           {capacity && (
             <IconWithText
               text={`${Number(capacity).toLocaleString()}人`}
@@ -49,11 +54,11 @@ export const StadiumDetail: FC<Props> = async ({ id }) => {
           )}
           <IconWithText text={homeTeams} icon="home" />
           <IconWithText text={address} icon="mapPin" />
-          <Text ml="md" fz="sm">
+          <Text ml={{ base: "sm", md: "md" }} fz={{ base: "xs", md: "sm" }} mt="xs">
             {access}
           </Text>
         </Box>
-        <Box w="100%" h="240px">
+        <Box w="100%" h={{ base: "200px", sm: "240px", md: "300px" }}>
           <GoogleMap lat={lat ?? 0} lng={lng ?? 0} />
         </Box>
       </Flex>

--- a/src/components/organisms/Teams/Detail/index.tsx
+++ b/src/components/organisms/Teams/Detail/index.tsx
@@ -2,7 +2,7 @@ import { Footer } from "@/components/organisms/Matches/Footer";
 import { MatchList } from "@/components/organisms/Matches/List";
 import { FallbackMatchList } from "@/components/organisms/Matches/List/fallback";
 import { getTeam } from "@/utils/supabase/db/actions";
-import { Paper } from "@mantine/core";
+import { Paper, Title } from "@mantine/core";
 import { Suspense, type FC } from "react";
 
 type Props = {
@@ -15,8 +15,10 @@ export const TeamDetail: FC<Props> = async ({ id, match_ym }) => {
 
   return (
     <div>
-      <Paper mb="md" withBorder p="sm">
-        {team?.name}
+      <Paper mb={{ base: "sm", md: "md" }} withBorder p={{ base: "sm", md: "md" }}>
+        <Title fz={{ base: "md", md: "lg" }} order={2}>
+          {team?.name}
+        </Title>
       </Paper>
       <Suspense fallback={<FallbackMatchList />}>
         <MatchList id={id} match_ym={match_ym} />


### PR DESCRIPTION
Issue #26 の Phase 2 を実装しました。

## 変更内容

### 2.1 スタジアム詳細ページ最適化
- 画像サイズのレスポンシブ設計
- 情報表示レイアウトのモバイル最適化
- Google Mapsの高さ調整

### 2.2 チーム詳細ページ最適化
- レスポンシブタイポグラフィの改善
- MatchCardコンポーネントのモバイル最適化
- Footerコンポーネントのタッチターゲット最適化

## テスト計画
- モバイル端末での詳細ページ表示確認
- レスポンシブ動作テスト
- タッチ操作の確認
- Google Mapsのモバイル操作確認

Generated with [Claude Code](https://claude.ai/code)