### PR TITLE
feat: 日程の表記変更 (7月05日 → 7月5日(土))

### DIFF
--- a/src/components/features/match/match-card/index.tsx
+++ b/src/components/features/match/match-card/index.tsx
@@ -38,13 +38,13 @@ export const MatchCard: FC<Props> = ({ match }) => {
     );
   }
 
-  const { month, day, hour, minute } = formatJstTime(match.date);
+  const { month, day, hour, minute, weekday } = formatJstTime(match.date);
 
   return (
     <Paper mb="sm" withBorder key={match.id}>
       <Flex justify="space-between" align="center" px="sm">
         <Text>
-          {`第${match.section}節`} {month}月{day}日
+          {`第${match.section}節`} {month}月{day}日({weekday})
         </Text>
         <Box>
           <NavLink

--- a/src/utils/functions/date.tsx
+++ b/src/utils/functions/date.tsx
@@ -4,6 +4,7 @@ type DateResult = {
   day?: string;
   hour?: string;
   minute?: string;
+  weekday?: string;
 };
 
 export const formatJstTime = (date: Date) => {
@@ -11,15 +12,16 @@ export const formatJstTime = (date: Date) => {
     timeZone: "Asia/Tokyo",
     year: "numeric",
     month: "numeric",
-    day: "2-digit",
+    day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+    weekday: "short",
   }).formatToParts(new Date(date));
 
-  const { year, month, day, hour, minute } = jstTime.reduce<DateResult>(
+  const { year, month, day, hour, minute, weekday } = jstTime.reduce<DateResult>(
     (prev, { type, value }) => ({ ...prev, [type]: value }),
     {}
   );
 
-  return { year, month, day, hour, minute };
+  return { year, month, day, hour, minute, weekday };
 };


### PR DESCRIPTION
## Summary
日程の表記を変更しました。

**変更前**: 7月05日
**変更後**: 7月5日(土)

## Changes
- `src/utils/functions/date.tsx`: 日付のゼロパディングを削除、曜日表示を追加
- `src/components/features/match/match-card/index.tsx`: 曜日を括弧内に表示

Closes #33

Generated with [Claude Code](https://claude.ai/code)