### PR TITLE
feat: add renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,15 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr",
+      "excludePackagePatterns": [
+        "^next$", "^@next/",
+        "^react$", "^@types/react",
+        "^@mantine/",
+        "^prisma$", "^@prisma/",
+        "^@supabase/",
+        "^@testing-library/", "^jest$", "^@playwright/", "^playwright$",
+        "^typescript$", "^@types/", "^eslint$", "^@eslint/", "^prettier$"
+      ],
       "addLabels": ["auto-merge"]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "schedule": [
+    "before 9am on monday"
+  ],
+  "timezone": "Asia/Tokyo",
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "groupName": "Next.js",
+      "matchPackagePatterns": ["^next", "@next/"],
+      "schedule": ["before 9am on monday"],
+      "automerge": false
+    },
+    {
+      "groupName": "React",
+      "matchPackagePatterns": ["^react", "^@types/react"],
+      "schedule": ["before 9am on monday"],
+      "automerge": false
+    },
+    {
+      "groupName": "Mantine UI",
+      "matchPackagePatterns": ["^@mantine/"],
+      "schedule": ["before 9am on monday"],
+      "automerge": false
+    },
+    {
+      "groupName": "Prisma",
+      "matchPackagePatterns": ["^prisma", "^@prisma/"],
+      "schedule": ["before 9am on monday"],
+      "automerge": false
+    },
+    {
+      "groupName": "Supabase",
+      "matchPackagePatterns": ["^@supabase/"],
+      "schedule": ["before 9am on monday"],
+      "automerge": false
+    },
+    {
+      "groupName": "Testing frameworks",
+      "matchPackagePatterns": ["^@testing-library/", "^jest", "^@playwright/", "^playwright"],
+      "schedule": ["before 9am on monday"],
+      "automerge": false
+    },
+    {
+      "groupName": "TypeScript and ESLint",
+      "matchPackagePatterns": ["^typescript", "^@types/", "^eslint", "^@eslint/", "^prettier"],
+      "schedule": ["before 9am on monday"],
+      "automerge": false
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "addLabels": ["auto-merge"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"]
+  },
+  "dependencyDashboard": true,
+  "rangeStrategy": "bump"
+}


### PR DESCRIPTION
Add renovate bot for automatic dependency updates

## Changes
- Add renovate.json with Next.js optimized settings
- Weekly Monday morning updates (JST timezone)
- Auto-merge for patch updates
- Grouped dependencies by framework
- Vulnerability alerts enabled

Closes #35

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 依存関係の自動更新を管理するためのRenovate Bot設定ファイルを追加しました。  
  * 主要なパッケージごとにグループ分けし、更新スケジュールや自動マージのルールを細かく設定しました。  
  * 脆弱性アラートと依存関係ダッシュボード機能が有効化され、更新は毎週月曜午前9時（アジア/東京）前に実行されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->